### PR TITLE
Add support for new rustdoc JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e3124c5a7883153fe3e762da9998cf36c302dbf1cc237869d297f9713e5655"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ba718a3adbe0a04a7b4760533c21b48289f66e70e0d25c53dbca2a75b58ec5"
+dependencies = [
+ "rustdoc-types 0.30.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +469,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 30.1.4",
  "trustfall-rustdoc-adapter 32.1.4",
  "trustfall-rustdoc-adapter 33.1.4",
+ "trustfall-rustdoc-adapter 34.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,10 @@ trustfall-rustdoc-adapter-v29 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v30 = { package = "trustfall-rustdoc-adapter", version = ">=30.1.4,<30.2.0", optional = true }
 trustfall-rustdoc-adapter-v32 = { package = "trustfall-rustdoc-adapter", version = ">=32.1.4,<32.2.0", optional = true }
 trustfall-rustdoc-adapter-v33 = { package = "trustfall-rustdoc-adapter", version = ">=33.1.4,<33.2.0", optional = true }
+trustfall-rustdoc-adapter-v34 = { package = "trustfall-rustdoc-adapter", version = ">=34.0.0,<34.1.0", optional = true }
 
 [features]
-default = ["v28", "v29", "v30", "v32", "v33"]
+default = ["v28", "v29", "v30", "v32", "v33", "v34"]
 v28 = ["dep:trustfall-rustdoc-adapter-v28"]
 v29 = ["dep:trustfall-rustdoc-adapter-v29"]
 v30 = ["dep:trustfall-rustdoc-adapter-v30"]
@@ -42,3 +43,4 @@ rustc-hash = [
     "trustfall-rustdoc-adapter-v32?/rustc-hash",
     "trustfall-rustdoc-adapter-v33?/rustc-hash",
 ]
+v34 = ["dep:trustfall-rustdoc-adapter-v34"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -78,6 +78,13 @@ pub fn load_rustdoc(path: &Path) -> anyhow::Result<VersionedCrate> {
             format_version,
         )?)),
 
+        #[cfg(feature = "v34")]
+        34 => Ok(VersionedCrate::V34(parse_or_report_error(
+            path,
+            &file_data,
+            format_version,
+        )?)),
+
         _ => bail!(
             "rustdoc format v{format_version} for file {} is not supported",
             path.display()

--- a/src/query.rs
+++ b/src/query.rs
@@ -37,6 +37,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V33(_, adapter) => {
                 execute_query(self.schema(), adapter.clone(), query, vars)
             }
+
+            #[cfg(feature = "v34")]
+            VersionedRustdocAdapter::V34(_, adapter) => {
+                execute_query(self.schema(), adapter.clone(), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -21,6 +21,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v33")]
                 Self::V33(..) => 33,
+
+                #[cfg(feature = "v34")]
+                Self::V34(..) => 34,
             }
         }
     };
@@ -43,6 +46,9 @@ pub enum VersionedCrate {
 
     #[cfg(feature = "v33")]
     V33(trustfall_rustdoc_adapter_v33::Crate),
+
+    #[cfg(feature = "v34")]
+    V34(trustfall_rustdoc_adapter_v34::Crate),
 }
 
 #[non_exhaustive]
@@ -62,6 +68,9 @@ pub enum VersionedIndexedCrate<'a> {
 
     #[cfg(feature = "v33")]
     V33(trustfall_rustdoc_adapter_v33::IndexedCrate<'a>),
+
+    #[cfg(feature = "v34")]
+    V34(trustfall_rustdoc_adapter_v34::IndexedCrate<'a>),
 }
 
 #[non_exhaustive]
@@ -95,6 +104,12 @@ pub enum VersionedRustdocAdapter<'a> {
         Schema,
         Arc<trustfall_rustdoc_adapter_v33::RustdocAdapter<'a>>,
     ),
+
+    #[cfg(feature = "v34")]
+    V34(
+        Schema,
+        Arc<trustfall_rustdoc_adapter_v34::RustdocAdapter<'a>>,
+    ),
 }
 
 impl VersionedCrate {
@@ -114,6 +129,9 @@ impl VersionedCrate {
 
             #[cfg(feature = "v33")]
             VersionedCrate::V33(c) => c.crate_version.as_deref(),
+
+            #[cfg(feature = "v34")]
+            VersionedCrate::V34(c) => c.crate_version.as_deref(),
         }
     }
 
@@ -146,6 +164,11 @@ impl<'a> VersionedIndexedCrate<'a> {
             #[cfg(feature = "v33")]
             VersionedCrate::V33(c) => {
                 Self::V33(trustfall_rustdoc_adapter_v33::IndexedCrate::new(c))
+            }
+
+            #[cfg(feature = "v34")]
+            VersionedCrate::V34(c) => {
+                Self::V34(trustfall_rustdoc_adapter_v34::IndexedCrate::new(c))
             }
         }
     }
@@ -266,6 +289,27 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v34")]
+            (VersionedIndexedCrate::V34(c), Some(VersionedIndexedCrate::V34(b))) => {
+                let adapter = Arc::new(trustfall_rustdoc_adapter_v34::RustdocAdapter::new(
+                    c,
+                    Some(b),
+                ));
+                Ok(VersionedRustdocAdapter::V34(
+                    trustfall_rustdoc_adapter_v34::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v34")]
+            (VersionedIndexedCrate::V34(c), None) => {
+                let adapter = Arc::new(trustfall_rustdoc_adapter_v34::RustdocAdapter::new(c, None));
+                Ok(VersionedRustdocAdapter::V34(
+                    trustfall_rustdoc_adapter_v34::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             (c, Some(b)) => {
                 bail!(
                     "version mismatch between current (v{}) and baseline (v{}) format versions",
@@ -292,6 +336,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v33")]
             VersionedRustdocAdapter::V33(schema, ..) => schema,
+
+            #[cfg(feature = "v34")]
+            VersionedRustdocAdapter::V34(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

