### PR TITLE
Add support for new rustdoc JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d368a6e25f5445187e8f67a7ec1cdf38f6d361fb26f9476b8b5f0bd91d88fd60"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +440,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "35.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfcab42255e407422af10215be3c335fd2a9d2ef7927c289c9a2b1b7608f596"
+dependencies = [
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.31.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +493,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 32.1.4",
  "trustfall-rustdoc-adapter 33.1.4",
  "trustfall-rustdoc-adapter 34.0.0",
+ "trustfall-rustdoc-adapter 35.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ trustfall-rustdoc-adapter-v30 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v32 = { package = "trustfall-rustdoc-adapter", version = ">=32.1.4,<32.2.0", optional = true }
 trustfall-rustdoc-adapter-v33 = { package = "trustfall-rustdoc-adapter", version = ">=33.1.4,<33.2.0", optional = true }
 trustfall-rustdoc-adapter-v34 = { package = "trustfall-rustdoc-adapter", version = ">=34.0.0,<34.1.0", optional = true }
+trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version = ">=35.0.0,<35.1.0", optional = true }
 
 [features]
-default = ["v28", "v29", "v30", "v32", "v33", "v34"]
+default = ["v28", "v29", "v30", "v32", "v33", "v34", "v35"]
 rayon = [
     "trustfall-rustdoc-adapter-v28?/rayon",
     "trustfall-rustdoc-adapter-v29?/rayon",
@@ -31,6 +32,7 @@ rayon = [
     "trustfall-rustdoc-adapter-v32?/rayon",
     "trustfall-rustdoc-adapter-v33?/rayon",
     "trustfall-rustdoc-adapter-v34?/rayon",
+    "trustfall-rustdoc-adapter-v35?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v28?/rustc-hash",
@@ -39,6 +41,7 @@ rustc-hash = [
     "trustfall-rustdoc-adapter-v32?/rustc-hash",
     "trustfall-rustdoc-adapter-v33?/rustc-hash",
     "trustfall-rustdoc-adapter-v34?/rustc-hash",
+    "trustfall-rustdoc-adapter-v35?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -48,3 +51,4 @@ v30 = ["dep:trustfall-rustdoc-adapter-v30"]
 v32 = ["dep:trustfall-rustdoc-adapter-v32"]
 v33 = ["dep:trustfall-rustdoc-adapter-v33"]
 v34 = ["dep:trustfall-rustdoc-adapter-v34"]
+v35 = ["dep:trustfall-rustdoc-adapter-v35"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,6 +85,13 @@ pub fn load_rustdoc(path: &Path) -> anyhow::Result<VersionedCrate> {
             format_version,
         )?)),
 
+        #[cfg(feature = "v35")]
+        35 => Ok(VersionedCrate::V35(parse_or_report_error(
+            path,
+            &file_data,
+            format_version,
+        )?)),
+
         _ => bail!(
             "rustdoc format v{format_version} for file {} is not supported",
             path.display()

--- a/src/query.rs
+++ b/src/query.rs
@@ -42,6 +42,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V34(_, adapter) => {
                 execute_query(self.schema(), adapter.clone(), query, vars)
             }
+
+            #[cfg(feature = "v35")]
+            VersionedRustdocAdapter::V35(_, adapter) => {
+                execute_query(self.schema(), adapter.clone(), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -24,6 +24,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v34")]
                 Self::V34(..) => 34,
+
+                #[cfg(feature = "v35")]
+                Self::V35(..) => 35,
             }
         }
     };
@@ -49,6 +52,9 @@ pub enum VersionedCrate {
 
     #[cfg(feature = "v34")]
     V34(trustfall_rustdoc_adapter_v34::Crate),
+
+    #[cfg(feature = "v35")]
+    V35(trustfall_rustdoc_adapter_v35::Crate),
 }
 
 #[non_exhaustive]
@@ -71,6 +77,9 @@ pub enum VersionedIndexedCrate<'a> {
 
     #[cfg(feature = "v34")]
     V34(trustfall_rustdoc_adapter_v34::IndexedCrate<'a>),
+
+    #[cfg(feature = "v35")]
+    V35(trustfall_rustdoc_adapter_v35::IndexedCrate<'a>),
 }
 
 #[non_exhaustive]
@@ -110,6 +119,12 @@ pub enum VersionedRustdocAdapter<'a> {
         Schema,
         Arc<trustfall_rustdoc_adapter_v34::RustdocAdapter<'a>>,
     ),
+
+    #[cfg(feature = "v35")]
+    V35(
+        Schema,
+        Arc<trustfall_rustdoc_adapter_v35::RustdocAdapter<'a>>,
+    ),
 }
 
 impl VersionedCrate {
@@ -132,6 +147,9 @@ impl VersionedCrate {
 
             #[cfg(feature = "v34")]
             VersionedCrate::V34(c) => c.crate_version.as_deref(),
+
+            #[cfg(feature = "v35")]
+            VersionedCrate::V35(c) => c.crate_version.as_deref(),
         }
     }
 
@@ -169,6 +187,11 @@ impl<'a> VersionedIndexedCrate<'a> {
             #[cfg(feature = "v34")]
             VersionedCrate::V34(c) => {
                 Self::V34(trustfall_rustdoc_adapter_v34::IndexedCrate::new(c))
+            }
+
+            #[cfg(feature = "v35")]
+            VersionedCrate::V35(c) => {
+                Self::V35(trustfall_rustdoc_adapter_v35::IndexedCrate::new(c))
             }
         }
     }
@@ -310,6 +333,27 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v35")]
+            (VersionedIndexedCrate::V35(c), Some(VersionedIndexedCrate::V35(b))) => {
+                let adapter = Arc::new(trustfall_rustdoc_adapter_v35::RustdocAdapter::new(
+                    c,
+                    Some(b),
+                ));
+                Ok(VersionedRustdocAdapter::V35(
+                    trustfall_rustdoc_adapter_v35::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v35")]
+            (VersionedIndexedCrate::V35(c), None) => {
+                let adapter = Arc::new(trustfall_rustdoc_adapter_v35::RustdocAdapter::new(c, None));
+                Ok(VersionedRustdocAdapter::V35(
+                    trustfall_rustdoc_adapter_v35::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             (c, Some(b)) => {
                 bail!(
                     "version mismatch between current (v{}) and baseline (v{}) format versions",
@@ -339,6 +383,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v34")]
             VersionedRustdocAdapter::V34(schema, ..) => schema,
+
+            #[cfg(feature = "v35")]
+            VersionedRustdocAdapter::V35(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

