### PR TITLE
Add support for new rustdoc JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0958527c2f4e8ff8b64e067bda402306946efc96f9b69f9f691b146f4b17f930"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +461,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf8370bfe8e00fde814e39a8fc6f5c8631fc6d49952fd7bee96e05698653add"
+dependencies = [
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.32.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +515,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 33.1.4",
  "trustfall-rustdoc-adapter 34.0.0",
  "trustfall-rustdoc-adapter 35.0.0",
+ "trustfall-rustdoc-adapter 36.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ trustfall-rustdoc-adapter-v32 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v33 = { package = "trustfall-rustdoc-adapter", version = ">=33.1.4,<33.2.0", optional = true }
 trustfall-rustdoc-adapter-v34 = { package = "trustfall-rustdoc-adapter", version = ">=34.0.0,<34.1.0", optional = true }
 trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version = ">=35.0.0,<35.1.0", optional = true }
+trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version = ">=36.0.0,<36.1.0", optional = true }
 
 [features]
-default = ["v28", "v29", "v30", "v32", "v33", "v34", "v35"]
+default = ["v28", "v29", "v30", "v32", "v33", "v34", "v35", "v36"]
 rayon = [
     "trustfall-rustdoc-adapter-v28?/rayon",
     "trustfall-rustdoc-adapter-v29?/rayon",
@@ -33,6 +34,7 @@ rayon = [
     "trustfall-rustdoc-adapter-v33?/rayon",
     "trustfall-rustdoc-adapter-v34?/rayon",
     "trustfall-rustdoc-adapter-v35?/rayon",
+    "trustfall-rustdoc-adapter-v36?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v28?/rustc-hash",
@@ -42,6 +44,7 @@ rustc-hash = [
     "trustfall-rustdoc-adapter-v33?/rustc-hash",
     "trustfall-rustdoc-adapter-v34?/rustc-hash",
     "trustfall-rustdoc-adapter-v35?/rustc-hash",
+    "trustfall-rustdoc-adapter-v36?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -52,3 +55,4 @@ v32 = ["dep:trustfall-rustdoc-adapter-v32"]
 v33 = ["dep:trustfall-rustdoc-adapter-v33"]
 v34 = ["dep:trustfall-rustdoc-adapter-v34"]
 v35 = ["dep:trustfall-rustdoc-adapter-v35"]
+v36 = ["dep:trustfall-rustdoc-adapter-v36"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,6 +92,13 @@ pub fn load_rustdoc(path: &Path) -> anyhow::Result<VersionedCrate> {
             format_version,
         )?)),
 
+        #[cfg(feature = "v36")]
+        36 => Ok(VersionedCrate::V36(parse_or_report_error(
+            path,
+            &file_data,
+            format_version,
+        )?)),
+
         _ => bail!(
             "rustdoc format v{format_version} for file {} is not supported",
             path.display()

--- a/src/query.rs
+++ b/src/query.rs
@@ -47,6 +47,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V35(_, adapter) => {
                 execute_query(self.schema(), adapter.clone(), query, vars)
             }
+
+            #[cfg(feature = "v36")]
+            VersionedRustdocAdapter::V36(_, adapter) => {
+                execute_query(self.schema(), adapter.clone(), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -27,6 +27,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v35")]
                 Self::V35(..) => 35,
+
+                #[cfg(feature = "v36")]
+                Self::V36(..) => 36,
             }
         }
     };
@@ -55,6 +58,9 @@ pub enum VersionedCrate {
 
     #[cfg(feature = "v35")]
     V35(trustfall_rustdoc_adapter_v35::Crate),
+
+    #[cfg(feature = "v36")]
+    V36(trustfall_rustdoc_adapter_v36::Crate),
 }
 
 #[non_exhaustive]
@@ -80,6 +86,9 @@ pub enum VersionedIndexedCrate<'a> {
 
     #[cfg(feature = "v35")]
     V35(trustfall_rustdoc_adapter_v35::IndexedCrate<'a>),
+
+    #[cfg(feature = "v36")]
+    V36(trustfall_rustdoc_adapter_v36::IndexedCrate<'a>),
 }
 
 #[non_exhaustive]
@@ -125,6 +134,12 @@ pub enum VersionedRustdocAdapter<'a> {
         Schema,
         Arc<trustfall_rustdoc_adapter_v35::RustdocAdapter<'a>>,
     ),
+
+    #[cfg(feature = "v36")]
+    V36(
+        Schema,
+        Arc<trustfall_rustdoc_adapter_v36::RustdocAdapter<'a>>,
+    ),
 }
 
 impl VersionedCrate {
@@ -150,6 +165,9 @@ impl VersionedCrate {
 
             #[cfg(feature = "v35")]
             VersionedCrate::V35(c) => c.crate_version.as_deref(),
+
+            #[cfg(feature = "v36")]
+            VersionedCrate::V36(c) => c.crate_version.as_deref(),
         }
     }
 
@@ -192,6 +210,11 @@ impl<'a> VersionedIndexedCrate<'a> {
             #[cfg(feature = "v35")]
             VersionedCrate::V35(c) => {
                 Self::V35(trustfall_rustdoc_adapter_v35::IndexedCrate::new(c))
+            }
+
+            #[cfg(feature = "v36")]
+            VersionedCrate::V36(c) => {
+                Self::V36(trustfall_rustdoc_adapter_v36::IndexedCrate::new(c))
             }
         }
     }
@@ -354,6 +377,27 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v36")]
+            (VersionedIndexedCrate::V36(c), Some(VersionedIndexedCrate::V36(b))) => {
+                let adapter = Arc::new(trustfall_rustdoc_adapter_v36::RustdocAdapter::new(
+                    c,
+                    Some(b),
+                ));
+                Ok(VersionedRustdocAdapter::V36(
+                    trustfall_rustdoc_adapter_v36::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v36")]
+            (VersionedIndexedCrate::V36(c), None) => {
+                let adapter = Arc::new(trustfall_rustdoc_adapter_v36::RustdocAdapter::new(c, None));
+                Ok(VersionedRustdocAdapter::V36(
+                    trustfall_rustdoc_adapter_v36::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             (c, Some(b)) => {
                 bail!(
                     "version mismatch between current (v{}) and baseline (v{}) format versions",
@@ -386,6 +430,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v35")]
             VersionedRustdocAdapter::V35(schema, ..) => schema,
+
+            #[cfg(feature = "v36")]
+            VersionedRustdocAdapter::V36(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

