### PR TITLE
Add support for new rustdoc JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33060dbec9e1d13d285c4cddc150a431569be97f33bf0b6c1ec6eea934c31ca"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +566,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3881686448ceb86978de52ed8da1989439df3289eda04c841a6fdb7b6f7b7b2"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.33.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +623,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 34.2.0",
  "trustfall-rustdoc-adapter 35.2.0",
  "trustfall-rustdoc-adapter 36.2.0",
+ "trustfall-rustdoc-adapter 37.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ trustfall-rustdoc-adapter-v33 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v34 = { package = "trustfall-rustdoc-adapter", version = ">=34.2.0,<34.3.0", optional = true }
 trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version = ">=35.2.0,<35.3.0", optional = true }
 trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version = ">=36.2.0,<36.3.0", optional = true }
+trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version = ">=37.0.0,<37.1.0", optional = true }
 
 [features]
-default = ["v30", "v32", "v33", "v34", "v35", "v36"]
+default = ["v30", "v32", "v33", "v34", "v35", "v36", "v37"]
 rayon = [
     "trustfall-rustdoc-adapter-v30?/rayon",
     "trustfall-rustdoc-adapter-v32?/rayon",
@@ -36,6 +37,7 @@ rayon = [
     "trustfall-rustdoc-adapter-v34?/rayon",
     "trustfall-rustdoc-adapter-v35?/rayon",
     "trustfall-rustdoc-adapter-v36?/rayon",
+    "trustfall-rustdoc-adapter-v37?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v30?/rustc-hash",
@@ -44,6 +46,7 @@ rustc-hash = [
     "trustfall-rustdoc-adapter-v34?/rustc-hash",
     "trustfall-rustdoc-adapter-v35?/rustc-hash",
     "trustfall-rustdoc-adapter-v36?/rustc-hash",
+    "trustfall-rustdoc-adapter-v37?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -53,3 +56,4 @@ v33 = ["dep:trustfall-rustdoc-adapter-v33"]
 v34 = ["dep:trustfall-rustdoc-adapter-v34"]
 v35 = ["dep:trustfall-rustdoc-adapter-v35"]
 v36 = ["dep:trustfall-rustdoc-adapter-v36"]
+v37 = ["dep:trustfall-rustdoc-adapter-v37"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -116,6 +116,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v37")]
+        37 => {
+            let rustdoc: trustfall_rustdoc_adapter_v37::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V37(
+                    trustfall_rustdoc_adapter_v37::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V37(
+                    trustfall_rustdoc_adapter_v37::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -42,6 +42,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V36(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v37")]
+            VersionedRustdocAdapter::V37(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -24,6 +24,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v36")]
                 Self::V36(..) => 36,
+
+                #[cfg(feature = "v37")]
+                Self::V37(..) => 37,
             }
         }
     };
@@ -49,6 +52,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v36")]
     V36(trustfall_rustdoc_adapter_v36::PackageStorage),
+
+    #[cfg(feature = "v37")]
+    V37(trustfall_rustdoc_adapter_v37::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -71,6 +77,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v36")]
     V36(trustfall_rustdoc_adapter_v36::PackageIndex<'a>),
+
+    #[cfg(feature = "v37")]
+    V37(trustfall_rustdoc_adapter_v37::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -92,6 +101,9 @@ pub enum VersionedRustdocAdapter<'a> {
 
     #[cfg(feature = "v36")]
     V36(Schema, trustfall_rustdoc_adapter_v36::RustdocAdapter<'a>),
+
+    #[cfg(feature = "v37")]
+    V37(Schema, trustfall_rustdoc_adapter_v37::RustdocAdapter<'a>),
 }
 
 impl VersionedStorage {
@@ -117,6 +129,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v36")]
             VersionedStorage::V36(s) => s.crate_version(),
+
+            #[cfg(feature = "v37")]
+            VersionedStorage::V37(s) => s.crate_version(),
         }
     }
 
@@ -154,6 +169,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v36")]
             VersionedStorage::V36(s) => {
                 Self::V36(trustfall_rustdoc_adapter_v36::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v37")]
+            VersionedStorage::V37(s) => {
+                Self::V37(trustfall_rustdoc_adapter_v37::PackageIndex::from_storage(s))
             }
         }
     }
@@ -275,6 +295,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v37")]
+            (VersionedIndex::V37(c), Some(VersionedIndex::V37(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v37::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V37(
+                    trustfall_rustdoc_adapter_v37::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v37")]
+            (VersionedIndex::V37(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v37::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V37(
+                    trustfall_rustdoc_adapter_v37::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -305,6 +343,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v36")]
             VersionedRustdocAdapter::V36(schema, ..) => schema,
+
+            #[cfg(feature = "v37")]
+            VersionedRustdocAdapter::V37(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

