### PR TITLE
Release v0.19 with more robust metadata processing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall_rustdoc"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall_rustdoc"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
It will no longer crash when given packages that depend on themselves, for example for the "SemVer trick".
