### PR TITLE
Add support for new rustdoc JSON format v39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf583db9958b3161d7980a56a8ee3c25e1a40708b81259be72584b7e0ea07c95"
+dependencies = [
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +544,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc35617188b049796d5dfb09aac65e8a63ff5e92a07ead8b6db37ae62a7a983"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.35.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +600,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 35.4.0",
  "trustfall-rustdoc-adapter 36.4.0",
  "trustfall-rustdoc-adapter 37.2.0",
+ "trustfall-rustdoc-adapter 39.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,17 @@ trustfall-rustdoc-adapter-v33 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version = ">=35.4.0,<35.5.0", optional = true }
 trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version = ">=36.4.0,<36.5.0", optional = true }
 trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version = ">=37.2.0,<37.3.0", optional = true }
+trustfall-rustdoc-adapter-v39 = { package = "trustfall-rustdoc-adapter", version = ">=39.0.0,<39.1.0", optional = true }
 
 [features]
-default = ["v32", "v33", "v35", "v36", "v37"]
+default = ["v32", "v33", "v35", "v36", "v37", "v39"]
 rayon = [
     "trustfall-rustdoc-adapter-v32?/rayon",
     "trustfall-rustdoc-adapter-v33?/rayon",
     "trustfall-rustdoc-adapter-v35?/rayon",
     "trustfall-rustdoc-adapter-v36?/rayon",
     "trustfall-rustdoc-adapter-v37?/rayon",
+    "trustfall-rustdoc-adapter-v39?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v32?/rustc-hash",
@@ -41,6 +43,7 @@ rustc-hash = [
     "trustfall-rustdoc-adapter-v35?/rustc-hash",
     "trustfall-rustdoc-adapter-v36?/rustc-hash",
     "trustfall-rustdoc-adapter-v37?/rustc-hash",
+    "trustfall-rustdoc-adapter-v39?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -49,3 +52,4 @@ v33 = ["dep:trustfall-rustdoc-adapter-v33"]
 v35 = ["dep:trustfall-rustdoc-adapter-v35"]
 v36 = ["dep:trustfall-rustdoc-adapter-v36"]
 v37 = ["dep:trustfall-rustdoc-adapter-v37"]
+v39 = ["dep:trustfall-rustdoc-adapter-v39"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -100,6 +100,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v39")]
+        39 => {
+            let rustdoc: trustfall_rustdoc_adapter_v39::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V39(
+                    trustfall_rustdoc_adapter_v39::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V39(
+                    trustfall_rustdoc_adapter_v39::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -37,6 +37,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V37(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v39")]
+            VersionedRustdocAdapter::V39(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -21,6 +21,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v37")]
                 Self::V37(..) => 37,
+
+                #[cfg(feature = "v39")]
+                Self::V39(..) => 39,
             }
         }
     };
@@ -43,6 +46,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v37")]
     V37(trustfall_rustdoc_adapter_v37::PackageStorage),
+
+    #[cfg(feature = "v39")]
+    V39(trustfall_rustdoc_adapter_v39::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -62,6 +68,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v37")]
     V37(trustfall_rustdoc_adapter_v37::PackageIndex<'a>),
+
+    #[cfg(feature = "v39")]
+    V39(trustfall_rustdoc_adapter_v39::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -80,6 +89,9 @@ pub enum VersionedRustdocAdapter<'a> {
 
     #[cfg(feature = "v37")]
     V37(Schema, trustfall_rustdoc_adapter_v37::RustdocAdapter<'a>),
+
+    #[cfg(feature = "v39")]
+    V39(Schema, trustfall_rustdoc_adapter_v39::RustdocAdapter<'a>),
 }
 
 impl VersionedStorage {
@@ -102,6 +114,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v37")]
             VersionedStorage::V37(s) => s.crate_version(),
+
+            #[cfg(feature = "v39")]
+            VersionedStorage::V39(s) => s.crate_version(),
         }
     }
 
@@ -134,6 +149,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v37")]
             VersionedStorage::V37(s) => {
                 Self::V37(trustfall_rustdoc_adapter_v37::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v39")]
+            VersionedStorage::V39(s) => {
+                Self::V39(trustfall_rustdoc_adapter_v39::PackageIndex::from_storage(s))
             }
         }
     }
@@ -237,6 +257,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v39")]
+            (VersionedIndex::V39(c), Some(VersionedIndex::V39(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v39::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V39(
+                    trustfall_rustdoc_adapter_v39::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v39")]
+            (VersionedIndex::V39(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v39::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V39(
+                    trustfall_rustdoc_adapter_v39::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -264,6 +302,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v37")]
             VersionedRustdocAdapter::V37(schema, ..) => schema,
+
+            #[cfg(feature = "v39")]
+            VersionedRustdocAdapter::V39(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

