### PR TITLE
Release v0.23.0, dropping rustdoc v35 and supporting rustdoc v43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
       - name: test rustdoc v39
         run: cargo test --no-default-features --features v39
 
+      - name: test rustdoc v43
+        run: cargo test --no-default-features --features v43
+
       # This line is a marker for our version-updating automation.
       # All per-feature tests must be added above this line.
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,6 @@ jobs:
         run: cargo test --no-run --all-features
 
       # Test features individually
-      - name: test rustdoc v35
-        run: cargo test --no-default-features --features v35
-
       - name: test rustdoc v36
         run: cargo test --no-default-features --features v36
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,15 +259,6 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustdoc-types"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d368a6e25f5445187e8f67a7ec1cdf38f6d361fb26f9476b8b5f0bd91d88fd60"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "rustdoc-types"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd5cb7a0c0a5a4f6bc429274fc1073d395237c83ef13d0ac728e0f95f5499ca"
@@ -469,20 +460,6 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "35.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cb60264d09c011f5344afd39263f575a32d82ce99cb391c49d70467603f466"
-dependencies = [
- "cargo_metadata",
- "cargo_toml",
- "rayon",
- "rustc-hash",
- "rustdoc-types 0.31.0",
- "trustfall",
-]
-
-[[package]]
-name = "trustfall-rustdoc-adapter"
 version = "36.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d69f817e08e139786c61c85010ee03d5f43f15c2807629291923011d070f0b"
@@ -575,7 +552,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "trustfall",
- "trustfall-rustdoc-adapter 35.5.3",
  "trustfall-rustdoc-adapter 36.5.4",
  "trustfall-rustdoc-adapter 37.3.4",
  "trustfall-rustdoc-adapter 39.1.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b61d5673c3f4b49d35be6a58c49210596f61b8db580bc3b6d9dee5e9dc5458"
+dependencies = [
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +524,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "43.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1777e00080c47bda32ea56917f0136769fb1225f4b564df07ffeb0929bb455f0"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.39.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +579,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 36.5.0",
  "trustfall-rustdoc-adapter 37.3.0",
  "trustfall-rustdoc-adapter 39.1.0",
+ "trustfall-rustdoc-adapter 43.0.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "async-graphql-parser"
-version = "7.0.11"
+version = "7.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79272bdbf26af97866e149f05b2b546edb5c00e51b5f916289931ed233e208ad"
+checksum = "4904895044116aab098ca82c6cec831ec43ed99efd04db9b70a390419bc88c5b"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "7.0.11"
+version = "7.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5ec94176a12a8cbe985cd73f2e54dc9c702c88c766bdef12f1f3a67cedbee1"
+checksum = "d0cde74de18e3a00c5dd5cfa002ab6f532e1a06c2a79ee6671e2fc353b400b92"
 dependencies = [
  "bytes",
  "indexmap",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -70,16 +70,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.3",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -113,33 +113,33 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "maplit"
@@ -175,29 +175,29 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 1.0.63",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -247,15 +247,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustdoc-types"
@@ -308,33 +308,33 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -343,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -364,18 +364,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -384,27 +384,27 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.63",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae0a56d0b642f6c64e683b8c29acfdc27a9cd384cea7e9ca32e7b24f2252b54"
+checksum = "d2c4d6f50f158998ff48a905a4f12e918b9dfd1274c0711c0f4485d8f7ff015e"
 dependencies = [
  "anyhow",
  "trustfall_core",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "35.5.0"
+version = "35.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b925dd481e3d3a67177bf5118626dc356037eb1e61af7a0ae0ff1f426da60927"
+checksum = "85cb60264d09c011f5344afd39263f575a32d82ce99cb391c49d70467603f466"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "36.5.0"
+version = "36.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893e13bd4f2a2341ef29b4731ac442259ad7beb20d6514a2ad8df9298620fb1b"
+checksum = "09d69f817e08e139786c61c85010ee03d5f43f15c2807629291923011d070f0b"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "37.3.0"
+version = "37.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4243569c6960eb2d48a40fd01a543318bb672d808619adcfcdec0d19637c5eb"
+checksum = "6c575fb2452dd70a5f09c84c786381349d0ae3cc5a30c778fe5766b92dd4bcd1"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall-rustdoc-adapter"
-version = "39.1.0"
+version = "39.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eedaaa8489d688fd7a3da825c7509a5596dfc5c50cc151fe76f90d4c075a6e82"
+checksum = "fee01298fdfa67b4f1378c1ca3a660564f37c5ea18ce028f0d22ae29231c8f63"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "trustfall_core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e206681a3cc2282151908aab9892c7227fe1a702c8b624700b201e5b66edc9"
+checksum = "363322af9d4d04fb0e298d8e9f97d9ef316a796f6f4e5f241060ad50a07d0334"
 dependencies = [
  "async-graphql-parser",
  "async-graphql-value",
@@ -551,7 +551,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 1.0.63",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -573,32 +573,32 @@ dependencies = [
  "cargo_metadata",
  "serde",
  "serde_json",
- "thiserror 2.0.3",
+ "thiserror 2.0.12",
  "trustfall",
- "trustfall-rustdoc-adapter 35.5.0",
- "trustfall-rustdoc-adapter 36.5.0",
- "trustfall-rustdoc-adapter 37.3.0",
- "trustfall-rustdoc-adapter 39.1.0",
+ "trustfall-rustdoc-adapter 35.5.3",
+ "trustfall-rustdoc-adapter 36.5.4",
+ "trustfall-rustdoc-adapter 37.3.4",
+ "trustfall-rustdoc-adapter 39.1.4",
  "trustfall-rustdoc-adapter 43.0.0",
 ]
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "trustfall_rustdoc"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trustfall_rustdoc"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 authors = ["Predrag Gruevski <obi1kenobi82@gmail.com>"]
 license = "Apache-2.0 OR MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,18 @@ readme = "./README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1.0.128"
+serde_json = "1.0.140"
 
 # All of the packages below are in our public API,
 # so bumping major versions for any of them is a major breaking change.
-anyhow = "1.0.89"
-cargo_metadata = "0.19.1"
-serde = { version = "1.0.210", features = ["derive"] }
-thiserror = "2.0.3"
-trustfall = "0.8.0"
-trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version = ">=35.5.0,<35.6.0", optional = true }
-trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version = ">=36.5.0,<36.6.0", optional = true }
-trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version = ">=37.3.0,<37.4.0", optional = true }
+anyhow = "1.0.97"
+cargo_metadata = "0.19.2"
+serde = { version = "1.0.219", features = ["derive"] }
+thiserror = "2.0.12"
+trustfall = "0.8.1"
+trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version = ">=35.5.3,<35.6.0", optional = true }
+trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version = ">=36.5.4,<36.6.0", optional = true }
+trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version = ">=37.3.4,<37.4.0", optional = true }
 trustfall-rustdoc-adapter-v39 = { package = "trustfall-rustdoc-adapter", version = ">=39.1.0,<39.2.0", optional = true }
 trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.0.0,<43.1.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,23 +20,20 @@ cargo_metadata = "0.19.2"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
 trustfall = "0.8.1"
-trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version = ">=35.5.3,<35.6.0", optional = true }
 trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version = ">=36.5.4,<36.6.0", optional = true }
 trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version = ">=37.3.4,<37.4.0", optional = true }
 trustfall-rustdoc-adapter-v39 = { package = "trustfall-rustdoc-adapter", version = ">=39.1.0,<39.2.0", optional = true }
 trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.0.0,<43.1.0", optional = true }
 
 [features]
-default = ["v35", "v36", "v37", "v39", "v43"]
+default = ["v36", "v37", "v39", "v43"]
 rayon = [
-    "trustfall-rustdoc-adapter-v35?/rayon",
     "trustfall-rustdoc-adapter-v36?/rayon",
     "trustfall-rustdoc-adapter-v37?/rayon",
     "trustfall-rustdoc-adapter-v39?/rayon",
     "trustfall-rustdoc-adapter-v43?/rayon",
 ]
 rustc-hash = [
-    "trustfall-rustdoc-adapter-v35?/rustc-hash",
     "trustfall-rustdoc-adapter-v36?/rustc-hash",
     "trustfall-rustdoc-adapter-v37?/rustc-hash",
     "trustfall-rustdoc-adapter-v39?/rustc-hash",
@@ -44,7 +41,6 @@ rustc-hash = [
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
-v35 = ["dep:trustfall-rustdoc-adapter-v35"]
 v36 = ["dep:trustfall-rustdoc-adapter-v36"]
 v37 = ["dep:trustfall-rustdoc-adapter-v37"]
 v39 = ["dep:trustfall-rustdoc-adapter-v39"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,23 @@ trustfall-rustdoc-adapter-v35 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version = ">=36.5.0,<36.6.0", optional = true }
 trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version = ">=37.3.0,<37.4.0", optional = true }
 trustfall-rustdoc-adapter-v39 = { package = "trustfall-rustdoc-adapter", version = ">=39.1.0,<39.2.0", optional = true }
+trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.0.0,<43.1.0", optional = true }
 
 [features]
-default = ["v35", "v36", "v37", "v39"]
+default = ["v35", "v36", "v37", "v39", "v43"]
 rayon = [
     "trustfall-rustdoc-adapter-v35?/rayon",
     "trustfall-rustdoc-adapter-v36?/rayon",
     "trustfall-rustdoc-adapter-v37?/rayon",
     "trustfall-rustdoc-adapter-v39?/rayon",
+    "trustfall-rustdoc-adapter-v43?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v35?/rustc-hash",
     "trustfall-rustdoc-adapter-v36?/rustc-hash",
     "trustfall-rustdoc-adapter-v37?/rustc-hash",
     "trustfall-rustdoc-adapter-v39?/rustc-hash",
+    "trustfall-rustdoc-adapter-v43?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -45,3 +48,4 @@ v35 = ["dep:trustfall-rustdoc-adapter-v35"]
 v36 = ["dep:trustfall-rustdoc-adapter-v36"]
 v37 = ["dep:trustfall-rustdoc-adapter-v37"]
 v39 = ["dep:trustfall-rustdoc-adapter-v39"]
+v43 = ["dep:trustfall-rustdoc-adapter-v43"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,22 +20,6 @@ pub fn load_rustdoc(
     let format_version = super::detect_rustdoc_format_version(path, &file_data)?;
 
     match format_version {
-        #[cfg(feature = "v35")]
-        35 => {
-            let rustdoc: trustfall_rustdoc_adapter_v35::Crate =
-                super::parse_or_report_error(path, &file_data, format_version)?;
-            match package {
-                Some(package) => Ok(VersionedStorage::V35(
-                    trustfall_rustdoc_adapter_v35::PackageStorage::from_rustdoc_and_package(
-                        rustdoc, package,
-                    ),
-                )),
-                None => Ok(VersionedStorage::V35(
-                    trustfall_rustdoc_adapter_v35::PackageStorage::from_rustdoc(rustdoc),
-                )),
-            }
-        }
-
         #[cfg(feature = "v36")]
         36 => {
             let rustdoc: trustfall_rustdoc_adapter_v36::Crate =

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,6 +84,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v43")]
+        43 => {
+            let rustdoc: trustfall_rustdoc_adapter_v43::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V43(
+                    trustfall_rustdoc_adapter_v43::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V43(
+                    trustfall_rustdoc_adapter_v43::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -32,6 +32,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V39(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v43")]
+            VersionedRustdocAdapter::V43(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -13,11 +13,6 @@ impl<'a> VersionedRustdocAdapter<'a> {
         vars: BTreeMap<K, V>,
     ) -> anyhow::Result<Box<dyn Iterator<Item = QueryResult> + 'a>> {
         match self {
-            #[cfg(feature = "v35")]
-            VersionedRustdocAdapter::V35(_, adapter) => {
-                execute_query(self.schema(), Arc::new(adapter), query, vars)
-            }
-
             #[cfg(feature = "v36")]
             VersionedRustdocAdapter::V36(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -18,6 +18,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v39")]
                 Self::V39(..) => 39,
+
+                #[cfg(feature = "v43")]
+                Self::V43(..) => 43,
             }
         }
     };
@@ -37,6 +40,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v39")]
     V39(trustfall_rustdoc_adapter_v39::PackageStorage),
+
+    #[cfg(feature = "v43")]
+    V43(trustfall_rustdoc_adapter_v43::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -53,6 +59,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v39")]
     V39(trustfall_rustdoc_adapter_v39::PackageIndex<'a>),
+
+    #[cfg(feature = "v43")]
+    V43(trustfall_rustdoc_adapter_v43::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -68,6 +77,9 @@ pub enum VersionedRustdocAdapter<'a> {
 
     #[cfg(feature = "v39")]
     V39(Schema, trustfall_rustdoc_adapter_v39::RustdocAdapter<'a>),
+
+    #[cfg(feature = "v43")]
+    V43(Schema, trustfall_rustdoc_adapter_v43::RustdocAdapter<'a>),
 }
 
 impl VersionedStorage {
@@ -87,6 +99,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v39")]
             VersionedStorage::V39(s) => s.crate_version(),
+
+            #[cfg(feature = "v43")]
+            VersionedStorage::V43(s) => s.crate_version(),
         }
     }
 
@@ -114,6 +129,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v39")]
             VersionedStorage::V39(s) => {
                 Self::V39(trustfall_rustdoc_adapter_v39::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v43")]
+            VersionedStorage::V43(s) => {
+                Self::V43(trustfall_rustdoc_adapter_v43::PackageIndex::from_storage(s))
             }
         }
     }
@@ -199,6 +219,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v43")]
+            (VersionedIndex::V43(c), Some(VersionedIndex::V43(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v43::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V43(
+                    trustfall_rustdoc_adapter_v43::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v43")]
+            (VersionedIndex::V43(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v43::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V43(
+                    trustfall_rustdoc_adapter_v43::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -223,6 +261,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v39")]
             VersionedRustdocAdapter::V39(schema, ..) => schema,
+
+            #[cfg(feature = "v43")]
+            VersionedRustdocAdapter::V43(schema, ..) => schema,
         }
     }
 

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -7,9 +7,6 @@ macro_rules! add_version_method {
     () => {
         pub fn version(&self) -> u32 {
             match self {
-                #[cfg(feature = "v35")]
-                Self::V35(..) => 35,
-
                 #[cfg(feature = "v36")]
                 Self::V36(..) => 36,
 
@@ -29,9 +26,6 @@ macro_rules! add_version_method {
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum VersionedStorage {
-    #[cfg(feature = "v35")]
-    V35(trustfall_rustdoc_adapter_v35::PackageStorage),
-
     #[cfg(feature = "v36")]
     V36(trustfall_rustdoc_adapter_v36::PackageStorage),
 
@@ -48,9 +42,6 @@ pub enum VersionedStorage {
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum VersionedIndex<'a> {
-    #[cfg(feature = "v35")]
-    V35(trustfall_rustdoc_adapter_v35::PackageIndex<'a>),
-
     #[cfg(feature = "v36")]
     V36(trustfall_rustdoc_adapter_v36::PackageIndex<'a>),
 
@@ -66,9 +57,6 @@ pub enum VersionedIndex<'a> {
 
 #[non_exhaustive]
 pub enum VersionedRustdocAdapter<'a> {
-    #[cfg(feature = "v35")]
-    V35(Schema, trustfall_rustdoc_adapter_v35::RustdocAdapter<'a>),
-
     #[cfg(feature = "v36")]
     V36(Schema, trustfall_rustdoc_adapter_v36::RustdocAdapter<'a>),
 
@@ -88,9 +76,6 @@ impl VersionedStorage {
     /// This is the version listed in the `Cargo.toml` of the crate, not its rustdoc format version.
     pub fn crate_version(&self) -> Option<&str> {
         match self {
-            #[cfg(feature = "v35")]
-            VersionedStorage::V35(s) => s.crate_version(),
-
             #[cfg(feature = "v36")]
             VersionedStorage::V36(s) => s.crate_version(),
 
@@ -111,11 +96,6 @@ impl VersionedStorage {
 impl<'a> VersionedIndex<'a> {
     pub fn from_storage(storage: &'a VersionedStorage) -> Self {
         match storage {
-            #[cfg(feature = "v35")]
-            VersionedStorage::V35(s) => {
-                Self::V35(trustfall_rustdoc_adapter_v35::PackageIndex::from_storage(s))
-            }
-
             #[cfg(feature = "v36")]
             VersionedStorage::V36(s) => {
                 Self::V36(trustfall_rustdoc_adapter_v36::PackageIndex::from_storage(s))
@@ -147,24 +127,6 @@ impl<'a> VersionedRustdocAdapter<'a> {
         baseline: Option<&'a VersionedIndex<'a>>,
     ) -> anyhow::Result<Self> {
         match (current, baseline) {
-            #[cfg(feature = "v35")]
-            (VersionedIndex::V35(c), Some(VersionedIndex::V35(b))) => {
-                let adapter = trustfall_rustdoc_adapter_v35::RustdocAdapter::new(c, Some(b));
-                Ok(VersionedRustdocAdapter::V35(
-                    trustfall_rustdoc_adapter_v35::RustdocAdapter::schema(),
-                    adapter,
-                ))
-            }
-
-            #[cfg(feature = "v35")]
-            (VersionedIndex::V35(c), None) => {
-                let adapter = trustfall_rustdoc_adapter_v35::RustdocAdapter::new(c, None);
-                Ok(VersionedRustdocAdapter::V35(
-                    trustfall_rustdoc_adapter_v35::RustdocAdapter::schema(),
-                    adapter,
-                ))
-            }
-
             #[cfg(feature = "v36")]
             (VersionedIndex::V36(c), Some(VersionedIndex::V36(b))) => {
                 let adapter = trustfall_rustdoc_adapter_v36::RustdocAdapter::new(c, Some(b));
@@ -250,9 +212,6 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
     pub fn schema(&self) -> &Schema {
         match self {
-            #[cfg(feature = "v35")]
-            VersionedRustdocAdapter::V35(schema, ..) => schema,
-
             #[cfg(feature = "v36")]
             VersionedRustdocAdapter::V36(schema, ..) => schema,
 


### PR DESCRIPTION
- **Support rustdoc JSON v43.**
- **Bump up minimum versions to compatible feature sets.**
- **Drop rustdoc v35.**
- **Release as v0.23.0.**
