### PR TITLE
Add support for new rustdoc JSON format v45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
       - name: test rustdoc v43
         run: cargo test --no-default-features --features v43
 
+      - name: test rustdoc v45
+        run: cargo test --no-default-features --features v45
+
       # This line is a marker for our version-updating automation.
       # All per-feature tests must be added above this line.
       #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79f6e675de57460d306a273321d3799b010b23713144caffe00b4a4fde83620e"
+dependencies = [
+ "rustc-hash",
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +525,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b56466cbd25682e4e54158db91fcc199c6db2d03d1dc9cdaf51e33d40a8cd2"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.41.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +580,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 37.3.4",
  "trustfall-rustdoc-adapter 39.1.4",
  "trustfall-rustdoc-adapter 43.0.0",
+ "trustfall-rustdoc-adapter 45.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,23 @@ trustfall-rustdoc-adapter-v36 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version = ">=37.3.4,<37.4.0", optional = true }
 trustfall-rustdoc-adapter-v39 = { package = "trustfall-rustdoc-adapter", version = ">=39.1.0,<39.2.0", optional = true }
 trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.0.0,<43.1.0", optional = true }
+trustfall-rustdoc-adapter-v45 = { package = "trustfall-rustdoc-adapter", version = ">=45.0.0,<45.1.0", optional = true }
 
 [features]
-default = ["v36", "v37", "v39", "v43"]
+default = ["v36", "v37", "v39", "v43", "v45"]
 rayon = [
     "trustfall-rustdoc-adapter-v36?/rayon",
     "trustfall-rustdoc-adapter-v37?/rayon",
     "trustfall-rustdoc-adapter-v39?/rayon",
     "trustfall-rustdoc-adapter-v43?/rayon",
+    "trustfall-rustdoc-adapter-v45?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v36?/rustc-hash",
     "trustfall-rustdoc-adapter-v37?/rustc-hash",
     "trustfall-rustdoc-adapter-v39?/rustc-hash",
     "trustfall-rustdoc-adapter-v43?/rustc-hash",
+    "trustfall-rustdoc-adapter-v45?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -45,3 +48,4 @@ v36 = ["dep:trustfall-rustdoc-adapter-v36"]
 v37 = ["dep:trustfall-rustdoc-adapter-v37"]
 v39 = ["dep:trustfall-rustdoc-adapter-v39"]
 v43 = ["dep:trustfall-rustdoc-adapter-v43"]
+v45 = ["dep:trustfall-rustdoc-adapter-v45"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,6 +84,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v45")]
+        45 => {
+            let rustdoc: trustfall_rustdoc_adapter_v45::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V45(
+                    trustfall_rustdoc_adapter_v45::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V45(
+                    trustfall_rustdoc_adapter_v45::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -32,6 +32,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V43(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v45")]
+            VersionedRustdocAdapter::V45(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -18,6 +18,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v43")]
                 Self::V43(..) => 43,
+
+                #[cfg(feature = "v45")]
+                Self::V45(..) => 45,
             }
         }
     };
@@ -37,6 +40,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v43")]
     V43(trustfall_rustdoc_adapter_v43::PackageStorage),
+
+    #[cfg(feature = "v45")]
+    V45(trustfall_rustdoc_adapter_v45::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -53,6 +59,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v43")]
     V43(trustfall_rustdoc_adapter_v43::PackageIndex<'a>),
+
+    #[cfg(feature = "v45")]
+    V45(trustfall_rustdoc_adapter_v45::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -68,6 +77,9 @@ pub enum VersionedRustdocAdapter<'a> {
 
     #[cfg(feature = "v43")]
     V43(Schema, trustfall_rustdoc_adapter_v43::RustdocAdapter<'a>),
+
+    #[cfg(feature = "v45")]
+    V45(Schema, trustfall_rustdoc_adapter_v45::RustdocAdapter<'a>),
 }
 
 impl VersionedStorage {
@@ -87,6 +99,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v43")]
             VersionedStorage::V43(s) => s.crate_version(),
+
+            #[cfg(feature = "v45")]
+            VersionedStorage::V45(s) => s.crate_version(),
         }
     }
 
@@ -114,6 +129,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v43")]
             VersionedStorage::V43(s) => {
                 Self::V43(trustfall_rustdoc_adapter_v43::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v45")]
+            VersionedStorage::V45(s) => {
+                Self::V45(trustfall_rustdoc_adapter_v45::PackageIndex::from_storage(s))
             }
         }
     }
@@ -199,6 +219,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v45")]
+            (VersionedIndex::V45(c), Some(VersionedIndex::V45(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v45::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V45(
+                    trustfall_rustdoc_adapter_v45::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v45")]
+            (VersionedIndex::V45(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v45::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V45(
+                    trustfall_rustdoc_adapter_v45::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -223,6 +261,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v43")]
             VersionedRustdocAdapter::V43(schema, ..) => schema,
+
+            #[cfg(feature = "v45")]
+            VersionedRustdocAdapter::V45(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

