### PR TITLE
Add support for new rustdoc JSON format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
       - name: test rustdoc v45
         run: cargo test --no-default-features --features v45
 
+      - name: test rustdoc v46
+        run: cargo test --no-default-features --features v46
+
       # This line is a marker for our version-updating automation.
       # All per-feature tests must be added above this line.
       #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203deadf94c78c2fbf43e3b35a687b6247f65757aa78452e232a35e935016af7"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +526,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "46.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35641ca97cd31194996c961e3d83e0e663cbc5407a5897f3c7ad14378966bc8d"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.46.1",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +581,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 39.1.0",
  "trustfall-rustdoc-adapter 43.0.0",
  "trustfall-rustdoc-adapter 45.0.0",
+ "trustfall-rustdoc-adapter 46.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,23 @@ trustfall-rustdoc-adapter-v37 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v39 = { package = "trustfall-rustdoc-adapter", version = ">=39.1.0,<39.2.0", optional = true }
 trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.0.0,<43.1.0", optional = true }
 trustfall-rustdoc-adapter-v45 = { package = "trustfall-rustdoc-adapter", version = ">=45.0.0,<45.1.0", optional = true }
+trustfall-rustdoc-adapter-v46 = { package = "trustfall-rustdoc-adapter", version = ">=46.0.0,<46.1.0", optional = true }
 
 [features]
-default = ["v37", "v39", "v43", "v45"]
+default = ["v37", "v39", "v43", "v45", "v46"]
 rayon = [
     "trustfall-rustdoc-adapter-v37?/rayon",
     "trustfall-rustdoc-adapter-v39?/rayon",
     "trustfall-rustdoc-adapter-v43?/rayon",
     "trustfall-rustdoc-adapter-v45?/rayon",
+    "trustfall-rustdoc-adapter-v46?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v37?/rustc-hash",
     "trustfall-rustdoc-adapter-v39?/rustc-hash",
     "trustfall-rustdoc-adapter-v43?/rustc-hash",
     "trustfall-rustdoc-adapter-v45?/rustc-hash",
+    "trustfall-rustdoc-adapter-v46?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -45,3 +48,4 @@ v37 = ["dep:trustfall-rustdoc-adapter-v37"]
 v39 = ["dep:trustfall-rustdoc-adapter-v39"]
 v43 = ["dep:trustfall-rustdoc-adapter-v43"]
 v45 = ["dep:trustfall-rustdoc-adapter-v45"]
+v46 = ["dep:trustfall-rustdoc-adapter-v46"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -84,6 +84,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v46")]
+        46 => {
+            let rustdoc: trustfall_rustdoc_adapter_v46::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V46(
+                    trustfall_rustdoc_adapter_v46::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V46(
+                    trustfall_rustdoc_adapter_v46::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -32,6 +32,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V45(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v46")]
+            VersionedRustdocAdapter::V46(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -18,6 +18,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v45")]
                 Self::V45(..) => 45,
+
+                #[cfg(feature = "v46")]
+                Self::V46(..) => 46,
             }
         }
     };
@@ -37,6 +40,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v45")]
     V45(trustfall_rustdoc_adapter_v45::PackageStorage),
+
+    #[cfg(feature = "v46")]
+    V46(trustfall_rustdoc_adapter_v46::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -53,6 +59,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v45")]
     V45(trustfall_rustdoc_adapter_v45::PackageIndex<'a>),
+
+    #[cfg(feature = "v46")]
+    V46(trustfall_rustdoc_adapter_v46::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -68,6 +77,9 @@ pub enum VersionedRustdocAdapter<'a> {
 
     #[cfg(feature = "v45")]
     V45(Schema, trustfall_rustdoc_adapter_v45::RustdocAdapter<'a>),
+
+    #[cfg(feature = "v46")]
+    V46(Schema, trustfall_rustdoc_adapter_v46::RustdocAdapter<'a>),
 }
 
 impl VersionedStorage {
@@ -87,6 +99,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v45")]
             VersionedStorage::V45(s) => s.crate_version(),
+
+            #[cfg(feature = "v46")]
+            VersionedStorage::V46(s) => s.crate_version(),
         }
     }
 
@@ -114,6 +129,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v45")]
             VersionedStorage::V45(s) => {
                 Self::V45(trustfall_rustdoc_adapter_v45::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v46")]
+            VersionedStorage::V46(s) => {
+                Self::V46(trustfall_rustdoc_adapter_v46::PackageIndex::from_storage(s))
             }
         }
     }
@@ -199,6 +219,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v46")]
+            (VersionedIndex::V46(c), Some(VersionedIndex::V46(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v46::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V46(
+                    trustfall_rustdoc_adapter_v46::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v46")]
+            (VersionedIndex::V46(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v46::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V46(
+                    trustfall_rustdoc_adapter_v46::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -223,6 +261,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v45")]
             VersionedRustdocAdapter::V45(schema, ..) => schema,
+
+            #[cfg(feature = "v46")]
+            VersionedRustdocAdapter::V46(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

