### PR TITLE
Add support for new rustdoc JSON format v48

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
       - name: test rustdoc v46
         run: cargo test --no-default-features --features v46
 
+      - name: test rustdoc v48
+        run: cargo test --no-default-features --features v48
+
       # This line is a marker for our version-updating automation.
       # All per-feature tests must be added above this line.
       #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50fc89b069580755b97b9b75e8fb80d7f44be4da1d259840938818dd10109df6"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +560,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "48.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417587199d6aebaac85983570e29601db4bc4c73646575378cf4c9bdd68448f4"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.48.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +616,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 43.1.0",
  "trustfall-rustdoc-adapter 45.1.0",
  "trustfall-rustdoc-adapter 46.1.0",
+ "trustfall-rustdoc-adapter 48.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,17 @@ trustfall-rustdoc-adapter-v39 = { package = "trustfall-rustdoc-adapter", version
 trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.1.0,<43.2.0", optional = true }
 trustfall-rustdoc-adapter-v45 = { package = "trustfall-rustdoc-adapter", version = ">=45.1.0,<45.2.0", optional = true }
 trustfall-rustdoc-adapter-v46 = { package = "trustfall-rustdoc-adapter", version = ">=46.1.0,<46.2.0", optional = true }
+trustfall-rustdoc-adapter-v48 = { package = "trustfall-rustdoc-adapter", version = ">=48.0.0,<48.1.0", optional = true }
 
 [features]
-default = ["v37", "v39", "v43", "v45", "v46"]
+default = ["v37", "v39", "v43", "v45", "v46", "v48"]
 rayon = [
     "trustfall-rustdoc-adapter-v37?/rayon",
     "trustfall-rustdoc-adapter-v39?/rayon",
     "trustfall-rustdoc-adapter-v43?/rayon",
     "trustfall-rustdoc-adapter-v45?/rayon",
     "trustfall-rustdoc-adapter-v46?/rayon",
+    "trustfall-rustdoc-adapter-v48?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v37?/rustc-hash",
@@ -41,6 +43,7 @@ rustc-hash = [
     "trustfall-rustdoc-adapter-v43?/rustc-hash",
     "trustfall-rustdoc-adapter-v45?/rustc-hash",
     "trustfall-rustdoc-adapter-v46?/rustc-hash",
+    "trustfall-rustdoc-adapter-v48?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
@@ -49,3 +52,4 @@ v39 = ["dep:trustfall-rustdoc-adapter-v39"]
 v43 = ["dep:trustfall-rustdoc-adapter-v43"]
 v45 = ["dep:trustfall-rustdoc-adapter-v45"]
 v46 = ["dep:trustfall-rustdoc-adapter-v46"]
+v48 = ["dep:trustfall-rustdoc-adapter-v48"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -100,6 +100,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v48")]
+        48 => {
+            let rustdoc: trustfall_rustdoc_adapter_v48::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V48(
+                    trustfall_rustdoc_adapter_v48::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V48(
+                    trustfall_rustdoc_adapter_v48::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -37,6 +37,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V46(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v48")]
+            VersionedRustdocAdapter::V48(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -21,6 +21,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v46")]
                 Self::V46(..) => 46,
+
+                #[cfg(feature = "v48")]
+                Self::V48(..) => 48,
             }
         }
     };
@@ -43,6 +46,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v46")]
     V46(trustfall_rustdoc_adapter_v46::PackageStorage),
+
+    #[cfg(feature = "v48")]
+    V48(trustfall_rustdoc_adapter_v48::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -62,6 +68,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v46")]
     V46(trustfall_rustdoc_adapter_v46::PackageIndex<'a>),
+
+    #[cfg(feature = "v48")]
+    V48(trustfall_rustdoc_adapter_v48::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -80,6 +89,9 @@ pub enum VersionedRustdocAdapter<'a> {
 
     #[cfg(feature = "v46")]
     V46(Schema, trustfall_rustdoc_adapter_v46::RustdocAdapter<'a>),
+
+    #[cfg(feature = "v48")]
+    V48(Schema, trustfall_rustdoc_adapter_v48::RustdocAdapter<'a>),
 }
 
 impl VersionedStorage {
@@ -102,6 +114,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v46")]
             VersionedStorage::V46(s) => s.crate_version(),
+
+            #[cfg(feature = "v48")]
+            VersionedStorage::V48(s) => s.crate_version(),
         }
     }
 
@@ -134,6 +149,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v46")]
             VersionedStorage::V46(s) => {
                 Self::V46(trustfall_rustdoc_adapter_v46::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v48")]
+            VersionedStorage::V48(s) => {
+                Self::V48(trustfall_rustdoc_adapter_v48::PackageIndex::from_storage(s))
             }
         }
     }
@@ -237,6 +257,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v48")]
+            (VersionedIndex::V48(c), Some(VersionedIndex::V48(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v48::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V48(
+                    trustfall_rustdoc_adapter_v48::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v48")]
+            (VersionedIndex::V48(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v48::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V48(
+                    trustfall_rustdoc_adapter_v48::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -264,6 +302,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v46")]
             VersionedRustdocAdapter::V46(schema, ..) => schema,
+
+            #[cfg(feature = "v48")]
+            VersionedRustdocAdapter::V48(schema, ..) => schema,
         }
     }
 


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

