### PR TITLE
Add support for new rustdoc JSON format v54

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
       - name: test rustdoc v53
         run: cargo test --no-default-features --features v53
 
+      - name: test rustdoc v54
+        run: cargo test --no-default-features --features v54
+
       # This line is a marker for our version-updating automation.
       # All per-feature tests must be added above this line.
       #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814bc4dddadb32bef41ec20b836b35aa7aaf88356c721a0dd9cda41331394b8b"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +513,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "54.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e345855c7f2f765cdea5a68a31104d95aeedb9a057c150b1baf3a026a4ccd8d"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "indexmap",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.54.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +568,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 43.2.2",
  "trustfall-rustdoc-adapter 45.2.2",
  "trustfall-rustdoc-adapter 53.1.2",
+ "trustfall-rustdoc-adapter 54.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,25 @@ trustfall = "0.8.1"
 trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.2.2,<43.3.0", optional = true }
 trustfall-rustdoc-adapter-v45 = { package = "trustfall-rustdoc-adapter", version = ">=45.2.2,<45.3.0", optional = true }
 trustfall-rustdoc-adapter-v53 = { package = "trustfall-rustdoc-adapter", version = ">=53.1.2,<53.2.0", optional = true }
+trustfall-rustdoc-adapter-v54 = { package = "trustfall-rustdoc-adapter", version = ">=54.0.0,<54.1.0", optional = true }
 
 [features]
-default = ["v43", "v45", "v53"]
+default = ["v43", "v45", "v53", "v54"]
 rayon = [
     "trustfall-rustdoc-adapter-v43?/rayon",
     "trustfall-rustdoc-adapter-v45?/rayon",
     "trustfall-rustdoc-adapter-v53?/rayon",
+    "trustfall-rustdoc-adapter-v54?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v43?/rustc-hash",
     "trustfall-rustdoc-adapter-v45?/rustc-hash",
     "trustfall-rustdoc-adapter-v53?/rustc-hash",
+    "trustfall-rustdoc-adapter-v54?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
 v43 = ["dep:trustfall-rustdoc-adapter-v43"]
 v45 = ["dep:trustfall-rustdoc-adapter-v45"]
 v53 = ["dep:trustfall-rustdoc-adapter-v53"]
+v54 = ["dep:trustfall-rustdoc-adapter-v54"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,6 +70,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v54")]
+        54 => {
+            let rustdoc: trustfall_rustdoc_adapter_v54::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V54(
+                    trustfall_rustdoc_adapter_v54::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V54(
+                    trustfall_rustdoc_adapter_v54::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -29,6 +29,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V53(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v54")]
+            VersionedRustdocAdapter::V54(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 }

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -17,6 +17,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v53")]
                 Self::V53(..) => 53,
+
+                #[cfg(feature = "v54")]
+                Self::V54(..) => 54,
             }
         }
     };
@@ -33,6 +36,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v53")]
     V53(trustfall_rustdoc_adapter_v53::PackageStorage),
+
+    #[cfg(feature = "v54")]
+    V54(trustfall_rustdoc_adapter_v54::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -46,6 +52,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v53")]
     V53(trustfall_rustdoc_adapter_v53::PackageIndex<'a>),
+
+    #[cfg(feature = "v54")]
+    V54(trustfall_rustdoc_adapter_v54::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -67,6 +76,12 @@ pub enum VersionedRustdocAdapter<'a> {
         &'static Schema,
         trustfall_rustdoc_adapter_v53::RustdocAdapter<'a>,
     ),
+
+    #[cfg(feature = "v54")]
+    V54(
+        &'static Schema,
+        trustfall_rustdoc_adapter_v54::RustdocAdapter<'a>,
+    ),
 }
 
 impl VersionedStorage {
@@ -83,6 +98,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v53")]
             VersionedStorage::V53(s) => s.crate_version(),
+
+            #[cfg(feature = "v54")]
+            VersionedStorage::V54(s) => s.crate_version(),
         }
     }
 
@@ -105,6 +123,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v53")]
             VersionedStorage::V53(s) => {
                 Self::V53(trustfall_rustdoc_adapter_v53::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v54")]
+            VersionedStorage::V54(s) => {
+                Self::V54(trustfall_rustdoc_adapter_v54::PackageIndex::from_storage(s))
             }
         }
     }
@@ -172,6 +195,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v54")]
+            (VersionedIndex::V54(c), Some(VersionedIndex::V54(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v54::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V54(
+                    trustfall_rustdoc_adapter_v54::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v54")]
+            (VersionedIndex::V54(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v54::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V54(
+                    trustfall_rustdoc_adapter_v54::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -193,6 +234,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v53")]
             VersionedRustdocAdapter::V53(schema, ..) => schema,
+
+            #[cfg(feature = "v54")]
+            VersionedRustdocAdapter::V54(schema, ..) => schema,
         }
     }
 
@@ -207,5 +251,7 @@ pub(crate) fn supported_versions() -> &'static [u32] {
         45,
         #[cfg(feature = "v53")]
         53,
+        #[cfg(feature = "v54")]
+        54,
     ]
 }


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

