### PR TITLE
Add `run_query_with_indexed_query` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 45.3.0",
  "trustfall-rustdoc-adapter 53.2.0",
  "trustfall-rustdoc-adapter 54.1.0",
+ "trustfall_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ cargo_metadata = "0.21.0"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
 trustfall = "0.8.1"
+trustfall_core = "0.8.1"  # Keep to the same version as trustfall.
 trustfall-rustdoc-adapter-v43 = { package = "trustfall-rustdoc-adapter", version = ">=43.3.0,<43.4.0", optional = true }
 trustfall-rustdoc-adapter-v45 = { package = "trustfall-rustdoc-adapter", version = ">=45.3.0,<45.4.0", optional = true }
 trustfall-rustdoc-adapter-v53 = { package = "trustfall-rustdoc-adapter", version = ">=53.2.0,<53.3.0", optional = true }

--- a/src/query.rs
+++ b/src/query.rs
@@ -36,4 +36,45 @@ impl<'a> VersionedRustdocAdapter<'a> {
             }
         }
     }
+
+    pub fn run_query_with_indexed_query<'slf: 'a, K: Into<Arc<str>>, V: Into<FieldValue>>(
+        &'slf self,
+        query: Arc<trustfall_core::ir::IndexedQuery>,
+        vars: BTreeMap<K, V>,
+    ) -> anyhow::Result<Box<dyn Iterator<Item = QueryResult> + 'a>> {
+        let vars = Arc::new(
+            vars.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
+
+        match self {
+            #[cfg(feature = "v43")]
+            VersionedRustdocAdapter::V43(_, adapter) => {
+                Ok(trustfall_core::interpreter::execution::interpret_ir(
+                    Arc::new(adapter),
+                    query,
+                    vars,
+                )?)
+            }
+
+            #[cfg(feature = "v45")]
+            VersionedRustdocAdapter::V45(_, adapter) => {
+                Ok(trustfall_core::interpreter::execution::interpret_ir(
+                    Arc::new(adapter),
+                    query,
+                    vars,
+                )?)
+            }
+
+            #[cfg(feature = "v53")]
+            VersionedRustdocAdapter::V53(_, adapter) => {
+                Ok(trustfall_core::interpreter::execution::interpret_ir(
+                    Arc::new(adapter),
+                    query,
+                    vars,
+                )?)
+            }
+        }
+    }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -75,6 +75,15 @@ impl<'a> VersionedRustdocAdapter<'a> {
                     vars,
                 )?)
             }
+
+            #[cfg(feature = "v54")]
+            VersionedRustdocAdapter::V54(_, adapter) => {
+                Ok(trustfall_core::interpreter::execution::interpret_ir(
+                    Arc::new(adapter),
+                    query,
+                    vars,
+                )?)
+            }
         }
     }
 }

--- a/template/query.rs.template
+++ b/template/query.rs.template
@@ -28,7 +28,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
         query: Arc<trustfall_core::ir::IndexedQuery>,
         vars: BTreeMap<K, V>,
     ) -> anyhow::Result<Box<dyn Iterator<Item = QueryResult> + 'a>> {
-        let vars = Arc::new(vars.into_iter().map(|(k, v)| (k.into(), v.into())).collect());
+        let vars = Arc::new(
+            vars.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        );
 
         match self {
             {{#each version_numbers}}

--- a/template/query.rs.template
+++ b/template/query.rs.template
@@ -22,4 +22,26 @@ impl<'a> VersionedRustdocAdapter<'a> {
             {{/each}}
         }
     }
+
+    pub fn run_query_with_indexed_query<'slf: 'a, K: Into<Arc<str>>, V: Into<FieldValue>>(
+        &'slf self,
+        query: Arc<trustfall_core::ir::IndexedQuery>,
+        vars: BTreeMap<K, V>,
+    ) -> anyhow::Result<Box<dyn Iterator<Item = QueryResult> + 'a>> {
+        let vars = Arc::new(vars.into_iter().map(|(k, v)| (k.into(), v.into())).collect());
+
+        match self {
+            {{#each version_numbers}}
+            #[cfg(feature = "v{{this}}")]
+            VersionedRustdocAdapter::V{{this}}(_, adapter) => {
+                Ok(trustfall_core::interpreter::execution::interpret_ir(
+                    Arc::new(adapter),
+                    query,
+                    vars,
+                )?)
+            }
+
+            {{/each}}
+        }
+    }
 }


### PR DESCRIPTION
**Purpose of Change**
About 60% of tests runtime in `cargo-semver-checks` is spent re-parsing the query.

**Describe the Change**
Add a new function that takes a parsed query.

**Alternatives**
It would be nice if this function could take the variables from the `IndexedQuery.ir_query`, but there isn't a clear API that would allow doing this.