### PR TITLE
Add support for new rustdoc JSON format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
       - name: test rustdoc v55
         run: cargo test --no-default-features --features v55
 
+      - name: test rustdoc v56
+        run: cargo test --no-default-features --features v56
+
       # This line is a marker for our version-updating automation.
       # All per-feature tests must be added above this line.
       #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bf787c529efe523ed9eb6dcdbaa5954d34329f08d5c243fce928441826ca90"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +761,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "trustfall-rustdoc-adapter"
+version = "56.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e29d548ad719af45ca599b7d20352c90f45fd951d27f689eeb3c64e2224a47"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml",
+ "indexmap",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.56.0",
+ "trustfall",
+]
+
+[[package]]
 name = "trustfall_core"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +816,7 @@ dependencies = [
  "trustfall-rustdoc-adapter 45.4.0",
  "trustfall-rustdoc-adapter 53.3.0",
  "trustfall-rustdoc-adapter 55.1.0",
+ "trustfall-rustdoc-adapter 56.0.0",
  "trustfall_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,21 +24,25 @@ trustfall_core = "0.8.1"  # Keep to the same version as trustfall.
 trustfall-rustdoc-adapter-v45 = { package = "trustfall-rustdoc-adapter", version = ">=45.4.0,<45.5.0", optional = true }
 trustfall-rustdoc-adapter-v53 = { package = "trustfall-rustdoc-adapter", version = ">=53.3.0,<53.4.0", optional = true }
 trustfall-rustdoc-adapter-v55 = { package = "trustfall-rustdoc-adapter", version = ">=55.1.0,<55.2.0", optional = true }
+trustfall-rustdoc-adapter-v56 = { package = "trustfall-rustdoc-adapter", version = ">=56.0.0,<56.1.0", optional = true }
 
 [features]
-default = ["v45", "v53", "v55"]
+default = ["v45", "v53", "v55", "v56"]
 rayon = [
     "trustfall-rustdoc-adapter-v45?/rayon",
     "trustfall-rustdoc-adapter-v53?/rayon",
     "trustfall-rustdoc-adapter-v55?/rayon",
+    "trustfall-rustdoc-adapter-v56?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v45?/rustc-hash",
     "trustfall-rustdoc-adapter-v53?/rustc-hash",
     "trustfall-rustdoc-adapter-v55?/rustc-hash",
+    "trustfall-rustdoc-adapter-v56?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
 v45 = ["dep:trustfall-rustdoc-adapter-v45"]
 v53 = ["dep:trustfall-rustdoc-adapter-v53"]
 v55 = ["dep:trustfall-rustdoc-adapter-v55"]
+v56 = ["dep:trustfall-rustdoc-adapter-v56"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -70,6 +70,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v56")]
+        56 => {
+            let rustdoc: trustfall_rustdoc_adapter_v56::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V56(
+                    trustfall_rustdoc_adapter_v56::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V56(
+                    trustfall_rustdoc_adapter_v56::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -29,6 +29,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V55(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v56")]
+            VersionedRustdocAdapter::V56(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 
@@ -64,6 +69,15 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v55")]
             VersionedRustdocAdapter::V55(_, adapter) => {
+                Ok(trustfall_core::interpreter::execution::interpret_ir(
+                    Arc::new(adapter),
+                    query,
+                    vars,
+                )?)
+            }
+
+            #[cfg(feature = "v56")]
+            VersionedRustdocAdapter::V56(_, adapter) => {
                 Ok(trustfall_core::interpreter::execution::interpret_ir(
                     Arc::new(adapter),
                     query,

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -17,6 +17,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v55")]
                 Self::V55(..) => 55,
+
+                #[cfg(feature = "v56")]
+                Self::V56(..) => 56,
             }
         }
     };
@@ -33,6 +36,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v55")]
     V55(trustfall_rustdoc_adapter_v55::PackageStorage),
+
+    #[cfg(feature = "v56")]
+    V56(trustfall_rustdoc_adapter_v56::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -46,6 +52,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v55")]
     V55(trustfall_rustdoc_adapter_v55::PackageIndex<'a>),
+
+    #[cfg(feature = "v56")]
+    V56(trustfall_rustdoc_adapter_v56::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -67,6 +76,12 @@ pub enum VersionedRustdocAdapter<'a> {
         &'static Schema,
         trustfall_rustdoc_adapter_v55::RustdocAdapter<'a>,
     ),
+
+    #[cfg(feature = "v56")]
+    V56(
+        &'static Schema,
+        trustfall_rustdoc_adapter_v56::RustdocAdapter<'a>,
+    ),
 }
 
 impl VersionedStorage {
@@ -83,6 +98,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v55")]
             VersionedStorage::V55(s) => s.crate_version(),
+
+            #[cfg(feature = "v56")]
+            VersionedStorage::V56(s) => s.crate_version(),
         }
     }
 
@@ -105,6 +123,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v55")]
             VersionedStorage::V55(s) => {
                 Self::V55(trustfall_rustdoc_adapter_v55::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v56")]
+            VersionedStorage::V56(s) => {
+                Self::V56(trustfall_rustdoc_adapter_v56::PackageIndex::from_storage(s))
             }
         }
     }
@@ -172,6 +195,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v56")]
+            (VersionedIndex::V56(c), Some(VersionedIndex::V56(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v56::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V56(
+                    trustfall_rustdoc_adapter_v56::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v56")]
+            (VersionedIndex::V56(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v56::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V56(
+                    trustfall_rustdoc_adapter_v56::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -193,6 +234,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v55")]
             VersionedRustdocAdapter::V55(schema, ..) => schema,
+
+            #[cfg(feature = "v56")]
+            VersionedRustdocAdapter::V56(schema, ..) => schema,
         }
     }
 
@@ -207,5 +251,7 @@ pub(crate) fn supported_versions() -> &'static [u32] {
         53,
         #[cfg(feature = "v55")]
         55,
+        #[cfg(feature = "v56")]
+        56,
     ]
 }


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

