### PR TITLE
Export supported_versions function publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,9 @@ mod parser;
 mod query;
 mod versioned;
 
-use versioned::supported_versions;
 pub use {
     parser::load_rustdoc,
-    versioned::{VersionedIndex, VersionedRustdocAdapter, VersionedStorage},
+    versioned::{supported_versions, VersionedIndex, VersionedRustdocAdapter, VersionedStorage},
 };
 
 #[derive(Deserialize)]

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -155,7 +155,7 @@ impl<'a> VersionedRustdocAdapter<'a> {
     add_version_method!();
 }
 
-pub(crate) fn supported_versions() -> &'static [u32] {
+pub fn supported_versions() -> &'static [u32] {
     &[
         #[cfg(feature = "v56")]
         56,


### PR DESCRIPTION
### What
Make the `supported_versions()` function public, exporting it from the crate's public API. This function returns the list of rustdoc JSON format versions that the library supports.

### Why
Enable downstream tools like cargo-semver-checks to query the supported rustdoc format versions programmatically and export them from their own interface.

Close https://github.com/obi1kenobi/cargo-semver-checks/issues/1555