### PR TITLE
Add support for new rustdoc JSON format v60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: test rustdoc v57
         run: cargo test --no-default-features --features v57
 
+      - name: test rustdoc v60
+        run: cargo test --no-default-features --features v60
+
       # This line is a marker for our version-updating automation.
       # All per-feature tests must be added above this line.
       #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.5",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa61aec073ec94791433ddf3df2323ff9d1711557c2a0eefb0f99cb4f8dca520"
+dependencies = [
+ "semver",
+ "serde",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -131,19 +142,20 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -280,6 +292,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-types"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5b3f47eac1cf443b5556c2351d68ea609197f7a40735c9725ce7515d6fd5e91"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,18 +319,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -328,11 +361,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -404,10 +437,25 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -420,19 +468,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "winnow",
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "trustfall"
@@ -452,7 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d529f0bd5550f02cfc0a4b74384058a0ceff90b4b7f8bfff28353cc75548131"
 dependencies = [
  "cargo_metadata",
- "cargo_toml",
+ "cargo_toml 0.22.3",
  "indexmap",
  "rayon",
  "rustc-hash",
@@ -467,11 +524,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52199a9faa87a0c40360bbfa2d0aa0aeea29e7ffda159fd91fead16f76a3e265"
 dependencies = [
  "cargo_metadata",
- "cargo_toml",
+ "cargo_toml 0.22.3",
  "indexmap",
  "rayon",
  "rustc-hash",
  "rustdoc-types 0.57.0",
+ "trustfall",
+]
+
+[[package]]
+name = "trustfall-rustdoc-adapter"
+version = "60.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557031fcc0a5f7ac758f3d728a8f475460bc62c660f369b2f3d4cf3ab8f47b7f"
+dependencies = [
+ "cargo_metadata",
+ "cargo_toml 1.0.0",
+ "indexmap",
+ "rayon",
+ "rustc-hash",
+ "rustdoc-types 0.60.0",
  "trustfall",
 ]
 
@@ -515,6 +587,7 @@ dependencies = [
  "trustfall",
  "trustfall-rustdoc-adapter 56.2.0",
  "trustfall-rustdoc-adapter 57.0.0",
+ "trustfall-rustdoc-adapter 60.0.0",
  "trustfall_core",
 ]
 
@@ -535,3 +608,9 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,22 @@ trustfall = "0.8.1"
 trustfall_core = "0.8.1"  # Keep to the same version as trustfall.
 trustfall-rustdoc-adapter-v56 = { package = "trustfall-rustdoc-adapter", version = ">=56.2.0,<56.3.0", optional = true }
 trustfall-rustdoc-adapter-v57 = { package = "trustfall-rustdoc-adapter", version = ">=57.0.0,<57.1.0", optional = true }
+trustfall-rustdoc-adapter-v60 = { package = "trustfall-rustdoc-adapter", version = ">=60.0.0,<60.1.0", optional = true }
 
 [features]
-default = ["v56", "v57"]
+default = ["v56", "v57", "v60"]
 rayon = [
     "trustfall-rustdoc-adapter-v56?/rayon",
     "trustfall-rustdoc-adapter-v57?/rayon",
+    "trustfall-rustdoc-adapter-v60?/rayon",
 ]
 rustc-hash = [
     "trustfall-rustdoc-adapter-v56?/rustc-hash",
     "trustfall-rustdoc-adapter-v57?/rustc-hash",
+    "trustfall-rustdoc-adapter-v60?/rustc-hash",
 ]
 # Keep this list of rustdoc version-specific features at the bottom,
 # to ensure our version-updating automation works correctly.
 v56 = ["dep:trustfall-rustdoc-adapter-v56"]
 v57 = ["dep:trustfall-rustdoc-adapter-v57"]
+v60 = ["dep:trustfall-rustdoc-adapter-v60"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -54,6 +54,22 @@ pub fn load_rustdoc(
             }
         }
 
+        #[cfg(feature = "v60")]
+        60 => {
+            let rustdoc: trustfall_rustdoc_adapter_v60::Crate =
+                super::parse_or_report_error(path, &file_data, format_version)?;
+            match package {
+                Some(package) => Ok(VersionedStorage::V60(
+                    trustfall_rustdoc_adapter_v60::PackageStorage::from_rustdoc_and_package(
+                        rustdoc, package,
+                    ),
+                )),
+                None => Ok(VersionedStorage::V60(
+                    trustfall_rustdoc_adapter_v60::PackageStorage::from_rustdoc(rustdoc),
+                )),
+            }
+        }
+
         _ => Err(LoadingError::UnsupportedFormat(
             format_version,
             path.display().to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -24,6 +24,11 @@ impl<'a> VersionedRustdocAdapter<'a> {
             VersionedRustdocAdapter::V57(_, adapter) => {
                 execute_query(self.schema(), Arc::new(adapter), query, vars)
             }
+
+            #[cfg(feature = "v60")]
+            VersionedRustdocAdapter::V60(_, adapter) => {
+                execute_query(self.schema(), Arc::new(adapter), query, vars)
+            }
         }
     }
 
@@ -50,6 +55,15 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v57")]
             VersionedRustdocAdapter::V57(_, adapter) => {
+                Ok(trustfall_core::interpreter::execution::interpret_ir(
+                    Arc::new(adapter),
+                    query,
+                    vars,
+                )?)
+            }
+
+            #[cfg(feature = "v60")]
+            VersionedRustdocAdapter::V60(_, adapter) => {
                 Ok(trustfall_core::interpreter::execution::interpret_ir(
                     Arc::new(adapter),
                     query,

--- a/src/versioned.rs
+++ b/src/versioned.rs
@@ -14,6 +14,9 @@ macro_rules! add_version_method {
 
                 #[cfg(feature = "v57")]
                 Self::V57(..) => 57,
+
+                #[cfg(feature = "v60")]
+                Self::V60(..) => 60,
             }
         }
     };
@@ -27,6 +30,9 @@ pub enum VersionedStorage {
 
     #[cfg(feature = "v57")]
     V57(trustfall_rustdoc_adapter_v57::PackageStorage),
+
+    #[cfg(feature = "v60")]
+    V60(trustfall_rustdoc_adapter_v60::PackageStorage),
 }
 
 #[non_exhaustive]
@@ -37,6 +43,9 @@ pub enum VersionedIndex<'a> {
 
     #[cfg(feature = "v57")]
     V57(trustfall_rustdoc_adapter_v57::PackageIndex<'a>),
+
+    #[cfg(feature = "v60")]
+    V60(trustfall_rustdoc_adapter_v60::PackageIndex<'a>),
 }
 
 #[non_exhaustive]
@@ -52,6 +61,12 @@ pub enum VersionedRustdocAdapter<'a> {
         &'static Schema,
         trustfall_rustdoc_adapter_v57::RustdocAdapter<'a>,
     ),
+
+    #[cfg(feature = "v60")]
+    V60(
+        &'static Schema,
+        trustfall_rustdoc_adapter_v60::RustdocAdapter<'a>,
+    ),
 }
 
 impl VersionedStorage {
@@ -65,6 +80,9 @@ impl VersionedStorage {
 
             #[cfg(feature = "v57")]
             VersionedStorage::V57(s) => s.crate_version(),
+
+            #[cfg(feature = "v60")]
+            VersionedStorage::V60(s) => s.crate_version(),
         }
     }
 
@@ -82,6 +100,11 @@ impl<'a> VersionedIndex<'a> {
             #[cfg(feature = "v57")]
             VersionedStorage::V57(s) => {
                 Self::V57(trustfall_rustdoc_adapter_v57::PackageIndex::from_storage(s))
+            }
+
+            #[cfg(feature = "v60")]
+            VersionedStorage::V60(s) => {
+                Self::V60(trustfall_rustdoc_adapter_v60::PackageIndex::from_storage(s))
             }
         }
     }
@@ -131,6 +154,24 @@ impl<'a> VersionedRustdocAdapter<'a> {
                 ))
             }
 
+            #[cfg(feature = "v60")]
+            (VersionedIndex::V60(c), Some(VersionedIndex::V60(b))) => {
+                let adapter = trustfall_rustdoc_adapter_v60::RustdocAdapter::new(c, Some(b));
+                Ok(VersionedRustdocAdapter::V60(
+                    trustfall_rustdoc_adapter_v60::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
+            #[cfg(feature = "v60")]
+            (VersionedIndex::V60(c), None) => {
+                let adapter = trustfall_rustdoc_adapter_v60::RustdocAdapter::new(c, None);
+                Ok(VersionedRustdocAdapter::V60(
+                    trustfall_rustdoc_adapter_v60::RustdocAdapter::schema(),
+                    adapter,
+                ))
+            }
+
             #[allow(unreachable_patterns)]
             (c, Some(b)) => {
                 bail!(
@@ -149,6 +190,9 @@ impl<'a> VersionedRustdocAdapter<'a> {
 
             #[cfg(feature = "v57")]
             VersionedRustdocAdapter::V57(schema, ..) => schema,
+
+            #[cfg(feature = "v60")]
+            VersionedRustdocAdapter::V60(schema, ..) => schema,
         }
     }
 
@@ -161,5 +205,7 @@ pub(crate) fn supported_versions() -> &'static [u32] {
         56,
         #[cfg(feature = "v57")]
         57,
+        #[cfg(feature = "v60")]
+        60,
     ]
 }


### PR DESCRIPTION
Automatically generated by the `add_new_rustdoc_version.yml` workflow.

